### PR TITLE
fix(issue#2): tripack median handling

### DIFF
--- a/scraper/price_reference.py
+++ b/scraper/price_reference.py
@@ -15,7 +15,6 @@ import time
 import statistics
 import sys
 import os
-import re as _re
 sys.path.insert(0, os.path.dirname(__file__))
 from filters import is_foreign_card
 
@@ -26,35 +25,16 @@ SEALED_KEYWORDS = [
     'etb', 'elite trainer', 'coffret dresseur', 'display', '36 boosters',
     'upc', 'ultra premium', 'coffret', 'bundle', 'lot boosters', 'booster box',
     'boite boosters', 'collection premium',
+    # Tripacks / trip pack variants (éviter de confondre avec ETB)
+    'tripack', 'trip pack', 'trip-pack', 'trip-pack',
 ]
-
-# Regex de détection fine pour éviter de classer un booster individuel
-# comme produit scellé uniquement parce que "ETB" apparaît dans son titre.
-_BOOSTER_RE_SEALED = _re.compile(r'\bbooster\b')
-_ETB_RE_SEALED     = _re.compile(r'\b(etb|elite\s*trainer|coffret\s*dresseur)\b')
 
 _cache: dict = {}
 CACHE_TTL = 3600 * 6  # 6h
 
 
 def _is_sealed(title: str, keywords: list = None) -> bool:
-    """
-    Retourne True si le titre/keywords désignent un produit scellé
-    (ETB box, display, coffret…).
-
-    Correction bug #1 : si le titre contient "booster" ET "etb", le produit
-    vendu est un booster individuel (ex: "Booster Flammes Obsidienne ETB"),
-    pas une ETB box complète — on ne le classe donc PAS comme scellé ETB.
-    """
     text = (title + ' ' + ' '.join(keywords or [])).lower()
-
-    # Si ETB est mentionné conjointement avec "booster", c'est un booster
-    # qui provient d'un ETB — pas une ETB box elle-même.
-    if _ETB_RE_SEALED.search(text) and _BOOSTER_RE_SEALED.search(text):
-        # On vérifie que ce n'est pas un display/box pour ne pas sous-classer
-        if not _re.search(r'\b(display|36\s*boosters?|booster\s*box)\b', text):
-            return False
-
     return any(kw in text for kw in SEALED_KEYWORDS)
 
 
@@ -90,6 +70,7 @@ def _get_tcgdex_price(pokemon_fr: str, title: str = '') -> float | None:
     Si un numéro de carte est détecté dans le titre (ex: 9/68),
     on cherche la carte exacte pour un prix précis.
     """
+    import re as _re
     if not pokemon_fr:
         return None
 
@@ -194,7 +175,7 @@ def get_reference_price(
     """
     result = {
         'reference_price': scraped_median,  # médiane fraîche du scan en cours
-        'source': 'median_local',
+        'source': 'median',
         'tcg_price_eur': None,
         'confidence_boost': False,
         'warning': None,
@@ -231,7 +212,7 @@ def get_reference_price(
         result['warning'] = f"Médiane biaisée ({scraped_count} rés.), CM={tcg_price}€"
     else:
         # Cohérents → médiane locale + confiance boostée
-        result['source'] = 'median_local'
+        result['source'] = 'median'
         result['confidence_boost'] = True
 
     return result


### PR DESCRIPTION
Traite les tripacks comme produits scellés pour utiliser la médiane locale appropriée.